### PR TITLE
Removed dependency on jumpstart_roles

### DIFF
--- a/stanford_private_page.info
+++ b/stanford_private_page.info
@@ -12,7 +12,6 @@ dependencies[] = image
 dependencies[] = stanford_image
 dependencies[] = strongarm
 dependencies[] = text
-dependencies[] = stanford_jumpstart_roles
 stylesheets[all][] = css/stanford_private_page.css
 scripts[] = js/stanford-private-page.js
 scripts[] = js/jquery.stanford-private-page.js

--- a/stanford_private_page.install
+++ b/stanford_private_page.install
@@ -3,29 +3,10 @@
  * Install tasks.
  */
 
- /**
- * Implements hook_requirements().
- */
-function stanford_private_page_requirements($phase) {
-  $requirements = array();
-  $t = get_t();
-  if ($phase == 'install') {
-    if (!module_exists('stanford_jumpstart_roles')) {
-      $requirements['stanford_private_page'] = array(
-        'title' => $t('Stanford Private Page'),
-        'description' => $t('Stanford Jumpstart Roles needs installed prior to Stanford Private Page'),
-        'value' => 'Stanford Jumpstart Roles is not enabled',
-        'severity' => REQUIREMENT_ERROR,
-      );
-    }
-  }
-  return $requirements;
-}
-
 /**
- * Implements hook_install().
+ * Implements hook_enable().
  */
-function stanford_private_page_install() {
+function stanford_private_page_enable() {
 
   // Let's keep the default settings defined in only one place
   $settings = stanford_private_page_get_settings();


### PR DESCRIPTION
Moved hook_install to hook_enable in order to ensure that the content_access settings have all of the roles during installation on both install profile and module install.
