### PR TITLE
Basic 2409 move files private

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,24 +1,130 @@
 engines:
+  # https://docs.codeclimate.com/docs/eslint
+  # ES Linting requires an .eslintrc file to tweak checks.
   eslint:
-    enabled: true
+    enabled: false
   csslint:
     enabled: true
-  phpcodesniffer:
-    enabled: true
-    config:
-      file_extensions: "php,inc,install,module,profile"
-      standard: "Drupal"
-  phpmd:
-    enabled: true
-    config:
-      file_extensions:
-      - inc
-      - module
-      - profile
-      - php
-      - install
+    checks:
+      overqualified-elements:
+        enabled: false
+      order-alphabetical:
+        enabled: false
+      adjoining-classes:
+        enabled: false
+      fallback-colors:
+        enabled: false
+      ids:
+        enabled: false
+      regex-selectors:
+        enabled: false
+  # We don't lint our coffee. Eew.
+  coffeelint:
+    enabled: false
+  # SCSS Lint requires a .scss-lint.yml file in the repo in order to tweak settings.
+  # Withouth the .scss-lint.yml file it will run with the defaults.
+  # Defaults file: https://github.com/brigade/scss-lint/blob/master/config/default.yml
   scss-lint:
     enabled: true
+    checks:
+      IdSelector:
+        enabled: false
+      SelectorFormat:
+        enabled: false
+      NestingDepth:
+        enabled: false
+      MergeableSelector:
+        enabled: false
+      ColorVariable:
+        enabled: false
+      PropertySortOrder:
+        enabled: false
+      SelectorDepth:
+        enabled: false
+      QualifyingElement:
+        enabled: false
+      VendorPrefix:
+        enabled: false
+      LeadingZero:
+        enabled: false
+      HexLength:
+        enabled: false
+      PseudoElement:
+        enabled: false
+  phpcodesniffer:
+    enabled: true
+    checks:
+      Drupal Commenting FunctionComment TypeHintMissing:
+        enabled: false
+      Drupal Commenting FunctionComment IncorrectTypeHint:
+        enabled: false
+      DrupalPractice Commenting CommentEmptyLine SpacingAfter:
+        enabled: false
+      Drupal NamingConventions ValidFunctionName ScopeNotCamelCaps:
+        enabled: false
+      Drupal NamingConventions ValidClassName StartWithCaptial:
+        enabled: false
+      Drupal NamingConventions ValidFunctionName NotCamelCaps:
+        enabled: false
+      DrupalPractice General ClassName ClassPrefix:
+        enabled: false
+      Drupal NamingConventions ValidClassName NoUnderscores:
+        enabled: false
+    config:
+      file_extensions: "php,inc,install,module,profile"
+      standard: "Drupal,DrupalPractice"
+  phpmd:
+    enabled: true
+    checks:
+      Design/WeightedMethodCount:
+        enabled: false
+      CleanCode/StaticAccess:
+        enabled: false
+      CleanCode/ElseExpression:
+        enabled: false
+      CleanCode/BooleanArgumentFlag:
+        enabled: false
+      UnusedFormalParameter:
+        enabled: false
+    config:
+      # https://phpmd.org/rules/index.html
+      # The following sets include everything except the controversial set.
+      # We can configure these further through .xml files. See docs.
+      rulesets: "cleancode,codesize,design,naming,unusedcode"
+      # Include special Drupal file extensions.
+      file_extensions: "inc,module,profile,php,install"
+  # https://docs.codeclimate.com/docs/phan
+  phan:
+    enabled: true
+    config:
+      file_extensions: "php,module,profile,inc,install"
+      # minimum-severity: 1
+      ignore-undeclared: true
+      # quick: true
+      # backward-compatiility-checks: true
+      # dead-code-detection: true
+  # https://docs.codeclimate.com/docs/duplication
+  duplication:
+    enabled: true
+    # exclude_paths:
+    #   - examples/
+    config:
+      languages:
+        javascript:
+          mass_threshold: 50
+          # count_threshold: 3
+        php:
+          mass_threshold: 60
+  fixme:
+    enabled: true
+    config:
+      strings:
+      - FIXME
+      - BUG
+      - TODO
+      - todo
+      - dpm
+      - dsm
 ratings:
   paths:
   - "**.inc"
@@ -26,11 +132,10 @@ ratings:
   - "**.profile"
   - "**.php"
   - "**.install"
-  - "**.css"
   - "**.scss"
   - "**.sass"
   - "**.js"
-##exclude these files/paths
+# exclude these files/paths
 exclude_paths:
 - "**.features.**"
 - "**.views_default.inc"
@@ -41,3 +146,10 @@ exclude_paths:
 - "test/**/*"
 - "**/vendor/**/*"
 - "**.min.*"
+- "tests/"
+- "spec/"
+- "**/vendor/"
+- "**.api.php"
+- "*.twig"
+- "**.tpl.php"
+- "**.strongarm.inc"

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,9 @@
+linters:
+  SingleLinePerSelector:
+    enabled: true
+    exclude:
+      - '**.css'
+  EmptyLineBetweenBlocks:
+    enabled: true
+    exclude:
+      - '**.css'

--- a/stanford_private_page.features.field_base.inc
+++ b/stanford_private_page.features.field_base.inc
@@ -27,7 +27,7 @@ function stanford_private_page_field_default_field_bases() {
     'settings' => array(
       'display_default' => 1,
       'display_field' => 1,
-      'uri_scheme' => 'public',
+      'uri_scheme' => 'private',
     ),
     'translatable' => 0,
     'type' => 'file',
@@ -49,7 +49,7 @@ function stanford_private_page_field_default_field_bases() {
     'module' => 'image',
     'settings' => array(
       'default_image' => 0,
-      'uri_scheme' => 'public',
+      'uri_scheme' => 'private',
     ),
     'translatable' => 0,
     'type' => 'image',

--- a/stanford_private_page.install
+++ b/stanford_private_page.install
@@ -70,12 +70,19 @@ function stanford_private_page_update_7001() {
     throw new DrupalUpdateException('Private directory is not writable.');
   }
 
+  db_update('system')
+    ->fields(array('status' => 0))
+    ->condition('name', 'stanford_private_page_administration')
+    ->execute();
+
   $fields = array(
     'field_s_private_file',
     'field_s_private_image_insert',
   );
 
   $file_paths = array();
+
+  $moved_files = array();
   foreach ($fields as $field_name) {
     $field_info = field_info_field($field_name);
     $field_info['settings']['uri_scheme'] = 'private';
@@ -89,8 +96,21 @@ function stanford_private_page_update_7001() {
       // Get the fid and load the original file.
       $column = $field_name . '_fid';
       $fid = $row[$column];
+
+      // Since we are querying the revision table, we have to track files that
+      // have already moved.
+      if (in_array($fid, $moved_files)) {
+        continue;
+      }
+      $moved_files[] = $fid;
+
       if ($file = file_load($fid)) {
         $new_dir = str_replace('public://', 'private://', $file->uri);
+
+        // Make sure the file actually exists.
+        if (!file_exists($file->uri)) {
+          continue;
+        }
 
         // Move the file to the new private directory.
         if ($new_file = file_move($file, $new_dir)) {
@@ -105,7 +125,6 @@ function stanford_private_page_update_7001() {
     db_query("UPDATE field_data_body SET body_value = REPLACE(body_value, '$old_url', '$new_url') where body_value like '%$old_url%'")->execute();
     db_query("UPDATE field_revision_body SET body_value = REPLACE(body_value, '$old_url', '$new_url') where body_value like '%$old_url%'")->execute();
   }
-
 }
 
 /**
@@ -118,6 +137,11 @@ function stanford_private_page_update_7002() {
       $destination = str_replace('public://', 'private://', $file->uri);
       file_move($file, $destination);
     }
+  }
+
+  // Flush image styles to protect derivatives.
+  foreach (image_styles() as $style) {
+    image_style_flush($style);
   }
 }
 

--- a/stanford_private_page.install
+++ b/stanford_private_page.install
@@ -61,11 +61,13 @@ function stanford_private_page_uninstall() {
  * Move files to private directory.
  */
 function stanford_private_page_update_7001() {
+  // Check if private directory is writable first.
   $dir = 'private://';
   file_prepare_directory($dir, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);
   if (!is_writable($dir)) {
     throw new DrupalUpdateException('Private directory is not writable.');
   }
+
   $fields = array(
     'field_s_private_file',
     'field_s_private_image_insert',
@@ -82,11 +84,13 @@ function stanford_private_page_update_7001() {
       ->execute();
 
     while ($row = $query->fetchAssoc()) {
+      // Get the fid and load the original file.
       $column = $field_name . '_fid';
       $fid = $row[$column];
       if ($file = file_load($fid)) {
         $new_dir = str_replace('public://', 'private://', $file->uri);
 
+        // Move the file to the new private directory.
         if ($new_file = file_move($file, $new_dir)) {
           $file_paths += stanford_private_page_get_paths($file->uri, $new_file->uri, $file->type);
         }
@@ -94,6 +98,7 @@ function stanford_private_page_update_7001() {
     }
   }
 
+  // Update any inline body urls.
   foreach ($file_paths as $old_url => $new_url) {
     db_query("UPDATE field_data_body SET body_value = REPLACE(body_value, '$old_url', '$new_url') where body_value like '%$old_url%'")->execute();
     db_query("UPDATE field_revision_body SET body_value = REPLACE(body_value, '$old_url', '$new_url') where body_value like '%$old_url%'")->execute();
@@ -130,6 +135,7 @@ function stanford_private_page_get_paths($old_uri, $new_uri, $file_type) {
     return $paths;
   }
 
+  // Get all image style paths.
   foreach (image_styles() as $style) {
     $old_style_uri = image_style_path($style['name'], $old_uri);
     $old_style = file_create_url($old_style_uri);
@@ -139,7 +145,7 @@ function stanford_private_page_get_paths($old_uri, $new_uri, $file_type) {
     $new_style = file_create_url($new_style_uri);
     $new_style = str_replace($base_url, '', $new_style);
 
-    $paths[$old_style] = "$new_style?itok=" . image_style_path_token($style['name'], $new_style_uri);
+    $paths[$old_style] = $new_style;
   }
 
   return $paths;

--- a/stanford_private_page.install
+++ b/stanford_private_page.install
@@ -1,5 +1,7 @@
 <?php
+
 /**
+ * @file
  * Install tasks.
  */
 
@@ -8,7 +10,7 @@
  */
 function stanford_private_page_enable() {
 
-  // Let's keep the default settings defined in only one place
+  // Let's keep the default settings defined in only one place.
   $settings = stanford_private_page_get_settings();
   variable_set('stanford_stanford_private_page_settings', $settings);
   // Setting access permissions for roles if they exist.

--- a/stanford_private_page.install
+++ b/stanford_private_page.install
@@ -107,6 +107,19 @@ function stanford_private_page_update_7001() {
 }
 
 /**
+ * Move field collection images to private directory.
+ */
+function stanford_private_page_update_7002() {
+  $query = db_query("select i.field_s_image_image_fid from field_revision_field_s_image_image i right join field_revision_field_s_image_info f on f.field_s_image_info_value = i.entity_id where f.entity_type = 'node' and f.bundle ='stanford_private_page'");
+  while ($fid = $query->fetchField()) {
+    if ($file = file_load($fid)) {
+      $destination = str_replace('public://', 'private://', $file->uri);
+      file_move($file, $destination);
+    }
+  }
+}
+
+/**
  * Get all replacement urls from an old uri to the new uri.
  *
  * @param string $old_uri

--- a/stanford_private_page.install
+++ b/stanford_private_page.install
@@ -36,11 +36,13 @@ function array_merge_recursive_ex(array & $array1, array & $array2) {
   foreach ($array2 as $key => & $value) {
     if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
       $merged[$key] = array_merge_recursive_ex($merged[$key], $value);
-    } elseif (is_numeric($key)) {
+    }
+    elseif (is_numeric($key)) {
       if (!in_array($value, $merged)) {
         $merged[] = $value;
       }
-    } else {
+    }
+    else {
       $merged[$key] = $value;
     }
   }
@@ -53,4 +55,92 @@ function array_merge_recursive_ex(array & $array1, array & $array2) {
 function stanford_private_page_uninstall() {
   variable_del('stanford_stanford_private_page_settings');
   variable_set('content_access_stanford_private_page', array());
+}
+
+/**
+ * Move files to private directory.
+ */
+function stanford_private_page_update_7001() {
+  $dir = 'private://';
+  file_prepare_directory($dir, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);
+  if (!is_writable($dir)) {
+    throw new DrupalUpdateException('Private directory is not writable.');
+  }
+  $fields = array(
+    'field_s_private_file',
+    'field_s_private_image_insert',
+  );
+
+  $file_paths = array();
+  foreach ($fields as $field_name) {
+    $field_info = field_info_field($field_name);
+    $field_info['settings']['uri_scheme'] = 'private';
+    field_update_field($field_info);
+
+    $query = db_select("field_revision_$field_name", 'f')
+      ->fields('f')
+      ->execute();
+
+    while ($row = $query->fetchAssoc()) {
+      $column = $field_name . '_fid';
+      $fid = $row[$column];
+      if ($file = file_load($fid)) {
+        $new_dir = str_replace('public://', 'private://', $file->uri);
+
+        if ($new_file = file_move($file, $new_dir)) {
+          $file_paths += stanford_private_page_get_paths($file->uri, $new_file->uri, $file->type);
+        }
+      }
+    }
+  }
+
+  foreach ($file_paths as $old_url => $new_url) {
+    db_query("UPDATE field_data_body SET body_value = REPLACE(body_value, '$old_url', '$new_url') where body_value like '%$old_url%'")->execute();
+    db_query("UPDATE field_revision_body SET body_value = REPLACE(body_value, '$old_url', '$new_url') where body_value like '%$old_url%'")->execute();
+  }
+
+}
+
+/**
+ * Get all replacement urls from an old uri to the new uri.
+ *
+ * @param string $old_uri
+ *   Old File URI.
+ * @param string $new_uri
+ *   New file URI.
+ * @param string $file_type
+ *   The type of file: image, document, other.
+ *
+ * @return array
+ *   Keyed array of paths that need to be replaced with old_path => new_path
+ */
+function stanford_private_page_get_paths($old_uri, $new_uri, $file_type) {
+  global $base_url;
+  $paths = array();
+
+  $old_url = file_create_url($old_uri);
+  $old_url = str_replace($base_url, '', $old_url);
+
+  $new_url = file_create_url($new_uri);
+  $new_url = str_replace($base_url, '', $new_url);
+
+  $paths[$old_url] = $new_url;
+
+  if ($file_type != 'image') {
+    return $paths;
+  }
+
+  foreach (image_styles() as $style) {
+    $old_style_uri = image_style_path($style['name'], $old_uri);
+    $old_style = file_create_url($old_style_uri);
+    $old_style = str_replace($base_url, '', $old_style);
+
+    $new_style_uri = image_style_path($style['name'], $new_uri);
+    $new_style = file_create_url($new_style_uri);
+    $new_style = str_replace($base_url, '', $new_style);
+
+    $paths[$old_style] = "$new_style?itok=" . image_style_path_token($style['name'], $new_style_uri);
+  }
+
+  return $paths;
 }

--- a/stanford_private_page.module
+++ b/stanford_private_page.module
@@ -244,7 +244,10 @@ function stanford_private_page_block_view($delta = '') {
 }
 
 /**
+ * Internal login block render.
+ *
  * @return array
+ *   Render array.
  */
 function stanford_internal_login_block_view() {
   $settings = stanford_private_page_get_settings();

--- a/stanford_private_page.module
+++ b/stanford_private_page.module
@@ -117,7 +117,7 @@ function stanford_private_page_settings_form_submit($form, &$form_state) {
 
   variable_set('stanford_stanford_private_page_settings', $new_settings);
 
-  drupal_set_message('Your settings have been saved.');
+  drupal_set_message(t('Your settings have been saved.'));
 }
 
 /**
@@ -140,7 +140,7 @@ function stanford_private_page_preprocess_page(&$vars) {
     if ($node->type == "stanford_private_page") {
       $settings = stanford_private_page_get_settings();
       if ($settings['display_message'] == TRUE) {
-        drupal_set_message("<p class='private-link'>" . $settings['message'] . '</p>', 'status', FALSE);
+        drupal_set_message("<p class='private-link'>" . $settings['message'] . '</p>');
       }
     }
   }

--- a/stanford_private_page.module
+++ b/stanford_private_page.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Code for the Stanford Private Page feature.
@@ -37,13 +38,15 @@ function stanford_private_page_menu() {
 
 /**
  * [stanford_private_page_settings_form description]
+ *
  * @param  [type] $form       [description]
  * @param  [type] $form_state [description]
+ *
  * @return [type]             [description]
  */
 function stanford_private_page_settings_form($form, &$form_state) {
 
-  // Get the previous settings
+  // Get the previous settings.
   $settings = stanford_private_page_get_settings();
 
   $form['settings'] = array(
@@ -69,7 +72,7 @@ function stanford_private_page_settings_form($form, &$form_state) {
     '#description' => t('This is message will appear on private pages.'),
   );
 
-  // and submit the form.
+  // And submit the form.
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save'),
@@ -79,7 +82,8 @@ function stanford_private_page_settings_form($form, &$form_state) {
 }
 
 /**
- * Default settings wrapper for variable_get
+ * Default settings wrapper for variable_get.
+ *
  * @return [type] [description]
  */
 function stanford_private_page_get_settings() {
@@ -89,15 +93,17 @@ function stanford_private_page_get_settings() {
     'internal_login_title' => t('Internal Login'),
     'internal_login_url' => 'private',
   );
-  $settings = variable_get('stanford_stanford_private_page_settings', $default_settings );
+  $settings = variable_get('stanford_stanford_private_page_settings', $default_settings);
 
   return $settings;
 }
 
 /**
  * [stanford_private_page_settings_form_submit description]
+ *
  * @param  [type] $form       [description]
  * @param  [type] $form_state [description]
+ *
  * @return [type]             [description]
  */
 function stanford_private_page_settings_form_submit($form, &$form_state) {
@@ -113,7 +119,8 @@ function stanford_private_page_settings_form_submit($form, &$form_state) {
 
   drupal_set_message('Your settings have been saved.');
 }
-/*
+
+/**
  * Implements hook_permission().
  */
 function stanford_private_page_permission() {
@@ -133,14 +140,17 @@ function stanford_private_page_preprocess_page(&$vars) {
     if ($node->type == "stanford_private_page") {
       $settings = stanford_private_page_get_settings();
       if ($settings['display_message'] == TRUE) {
-       drupal_set_message("<p class='private-link'>" . $settings['message'] . '</p>', 'status', FALSE);
+        drupal_set_message("<p class='private-link'>" . $settings['message'] . '</p>', 'status', FALSE);
       }
     }
   }
 }
 
+/**
+ * Implements hook_wysiwyg_editor_settings_alter().
+ */
 function stanford_private_page_wysiwyg_editor_settings_alter(&$settings, $context) {
-  // add editor CSS to fix overflow issue.
+  // Add editor CSS to fix overflow issue.
   $editor_css = url(drupal_get_path('module', 'stanford_private_page') . '/css/stanford_private_page.css');
   $settings['contentsCss'][] = $editor_css;
 
@@ -157,7 +167,6 @@ function stanford_private_page_wysiwyg_editor_settings_alter(&$settings, $contex
 
 }
 
-
 /**
  * Implements hook_block_info().
  */
@@ -169,17 +178,18 @@ function stanford_private_page_block_info() {
 
   return $blocks;
 }
+
 /**
  * Implements hook_block_configure().
  */
-function stanford_private_page_block_configure($delta='') {
+function stanford_private_page_block_configure($delta = '') {
   $form = array();
 
-  switch($delta) {
-    case 'stanford_internal_login' :
+  switch ($delta) {
+    case 'stanford_internal_login':
       $settings = stanford_private_page_get_settings();
 
-      // Title
+      // Title.
       $form['internal_login_title'] = array(
         '#type' => 'textfield',
         '#title' => t('Internal Login Button Title'),
@@ -187,7 +197,7 @@ function stanford_private_page_block_configure($delta='') {
         '#required' => TRUE,
       );
 
-      // URL
+      // URL.
       $form['internal_login_url'] = array(
         '#type' => 'textfield',
         '#title' => t('Internal Login Button URL'),
@@ -204,8 +214,8 @@ function stanford_private_page_block_configure($delta='') {
  * Implements hook_block_save().
  */
 function stanford_private_page_block_save($delta = '', $edit = array()) {
-  switch($delta) {
-    case 'stanford_internal_login' :
+  switch ($delta) {
+    case 'stanford_internal_login':
 
       $settings = stanford_private_page_get_settings();
       $new_settings = array_merge($settings, $edit);
@@ -217,14 +227,15 @@ function stanford_private_page_block_save($delta = '', $edit = array()) {
       break;
   }
 }
+
 /**
  * Implements hook_block_view().
  */
-function stanford_private_page_block_view($delta='') {
+function stanford_private_page_block_view($delta = '') {
   $block = array();
 
-  switch($delta) {
-    case 'stanford_internal_login' :
+  switch ($delta) {
+    case 'stanford_internal_login':
       $block['content'] = stanford_internal_login_block_view();
       break;
   }
@@ -232,9 +243,10 @@ function stanford_private_page_block_view($delta='') {
   return $block;
 }
 
-function stanford_internal_login_block_view()
-{
-  $block = array();
+/**
+ * @return array
+ */
+function stanford_internal_login_block_view() {
   $settings = stanford_private_page_get_settings();
   $block = array(
     'internal_login_link' => array(
@@ -245,4 +257,51 @@ function stanford_internal_login_block_view()
     ),
   );
   return $block;
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function stanford_private_page_entity_insert($entity, $type) {
+  if (
+    $type == 'field_collection_item' &&
+    $entity->field_name == 'field_s_image_info' &&
+    $entity->hostEntityBundle() == 'stanford_private_page'
+  ) {
+    stanford_private_page_move_field_collection_image($entity);
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function stanford_private_page_entity_update($entity, $type) {
+  if (
+    $type == 'field_collection_item' &&
+    $entity->field_name == 'field_s_image_info' &&
+    $entity->hostEntityBundle() == 'stanford_private_page'
+  ) {
+    stanford_private_page_move_field_collection_image($entity);
+  }
+}
+
+/**
+ * Move public files to private directory.
+ *
+ * @param object $entity
+ *   Field collection on the private page.
+ */
+function stanford_private_page_move_field_collection_image($entity) {
+  $images = field_get_items('field_collection_item', $entity, 'field_s_image_image');
+  if (!is_array($images)) {
+    return;
+  }
+
+  foreach ($images as $image) {
+    $file = file_load($image['fid']);
+    if (file_uri_scheme($file->uri) == 'public') {
+      $new_destination = str_replace('public://', 'private://', $file->uri);
+      file_move($file, $new_destination);
+    }
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Move files to private directory
- Change field to upload new files to private
- Added entity hook to move field collection images on save

# Needed By (Date)
- ASAP

# Urgency
- High

# Steps to Test

1. clone one of the sites that is using private page with files
2. checkout this branch
3. run drush updb
4. view a private page to ensure the files/images were moved to private directory (links should be like `somesite.local/system/files/myfile.pdf`
5. test access to that file link:
  If a user has access to the private page node, they should have access to the file
  If a user gets access denied when viewing the node, the file should get the same.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)