### PR TITLE
check if the private directory is set

### DIFF
--- a/stanford_private_page.install
+++ b/stanford_private_page.install
@@ -63,6 +63,11 @@ function stanford_private_page_uninstall() {
  * Move files to private directory.
  */
 function stanford_private_page_update_7001() {
+  // Make sure the private path is configured.
+  if (!variable_get('file_private_path', FALSE)) {
+    throw new DrupalUpdateException('Private directory is not configured.');
+  }
+
   // Check if private directory is writable first.
   $dir = 'private://';
   file_prepare_directory($dir, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);


### PR DESCRIPTION
# READY FOR REVIEW
# Summary
- Check for the variable. if the directory path is not configured, the `private://` file wrapper won't work.

# Needed By (Date)
- asap

# Urgency
- High

# Steps to Test

1. Manual review


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)