### PR TITLE
SOE-2582 Remove query that disables the admin module

### DIFF
--- a/stanford_private_page.install
+++ b/stanford_private_page.install
@@ -75,11 +75,6 @@ function stanford_private_page_update_7001() {
     throw new DrupalUpdateException('Private directory is not writable.');
   }
 
-  db_update('system')
-    ->fields(array('status' => 0))
-    ->condition('name', 'stanford_private_page_administration')
-    ->execute();
-
   $fields = array(
     'field_s_private_file',
     'field_s_private_image_insert',


### PR DESCRIPTION

# READY FOR REVIEW

# Summary
- This bug fix removes the code from the update hook that disabled the _stanford_private_page_administration_ module.

# Needed By (Date)
- _Leapin' Lizard_ Sprint end

# Criticality
- Client is eagerly awaiting this. This is to be rolled out on the SoE intranet site.
- Fixes broken stuff

# Steps to Test
- On a site with _Stanford Private Page_ enabled
- Switch to this branch
- Verify that updates for Private Page 7001 and 7002 _have not_ been run. (I changed the schema_version for _stanford_private_page_ to 0 in the system table)
- Verify that _stanford_private_page_administration_ module is enabled
- Run update.php or `drush updb`
- Verify that _stanford_private_page_administration_ module is still enabled

# Affects 
- Stanford Private Page Module

# Associated Issues and/or People

## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-2582
https://stanfordits.atlassian.net/browse/SOE-2573
https://stanfordits.atlassian.net/browse/SOE-2539

## Related PRs

## More Information

## Folks to notify
@minorwm 


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5): Removed database query to disable admin module